### PR TITLE
Add gallery screen with media permissions and navigation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/io/mayu/birdpilot/GalleryScreen.kt
+++ b/app/src/main/java/io/mayu/birdpilot/GalleryScreen.kt
@@ -1,0 +1,166 @@
+package io.mayu.birdpilot
+
+import android.content.ContentUris
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import android.provider.MediaStore
+import android.util.Size
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@Composable
+fun GalleryScreen(onBack: () -> Unit) {
+    BackHandler(onBack = onBack)
+
+    val context = LocalContext.current
+    val imageUris = remember { mutableStateListOf<Uri>() }
+
+    LaunchedEffect(Unit) {
+        val uris = withContext(Dispatchers.IO) {
+            loadLatestImages(context)
+        }
+        imageUris.clear()
+        imageUris.addAll(uris)
+    }
+
+    Surface(color = Color.Black, modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            GalleryTopBar(onBack = onBack)
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(3),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                contentPadding = PaddingValues(4.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                items(imageUris, key = { it.toString() }) { uri ->
+                    GalleryThumbnail(uri = uri)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GalleryTopBar(onBack: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.Black)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        IconButton(
+            onClick = onBack,
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(Color.White.copy(alpha = 0.1f))
+        ) {
+            Text(text = "←", color = Color.White, style = MaterialTheme.typography.titleMedium)
+        }
+        Text(
+            text = "ギャラリー",
+            color = Color.White,
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.align(Alignment.Center)
+        )
+    }
+}
+
+@Composable
+private fun GalleryThumbnail(uri: Uri) {
+    val context = LocalContext.current
+    var bitmap by remember(uri) { mutableStateOf<Bitmap?>(null) }
+
+    LaunchedEffect(uri) {
+        bitmap = withContext(Dispatchers.IO) {
+            runCatching {
+                context.contentResolver.loadThumbnail(uri, Size(300, 300), null)
+            }.getOrNull()
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .aspectRatio(1f)
+            .clip(MaterialTheme.shapes.small)
+            .background(Color.DarkGray),
+        contentAlignment = Alignment.Center
+    ) {
+        val thumb = bitmap
+        if (thumb != null) {
+            Image(
+                bitmap = thumb.asImageBitmap(),
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+        } else {
+            Text(text = "…", color = Color.White)
+        }
+    }
+}
+
+private fun loadLatestImages(context: Context): List<Uri> {
+    val projection = arrayOf(MediaStore.Images.Media._ID)
+    val selection = "${MediaStore.Images.Media.RELATIVE_PATH} = ?"
+    val selectionArgs = arrayOf("DCIM/BirdCam")
+    val sortOrder = "${MediaStore.Images.Media.DATE_TAKEN} DESC LIMIT 20"
+
+    val uris = mutableListOf<Uri>()
+    context.contentResolver.query(
+        MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+        projection,
+        selection,
+        selectionArgs,
+        sortOrder
+    )?.use { cursor ->
+        val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID)
+        while (cursor.moveToNext()) {
+            val id = cursor.getLong(idColumn)
+            val contentUri = ContentUris.withAppendedId(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, id)
+            uris.add(contentUri)
+        }
+    }
+    return uris
+}


### PR DESCRIPTION
## Summary
- add a compose-based gallery screen that queries the latest BirdCam captures and shows them in a 3-column grid
- add navigation from the camera screen to the gallery via a new button and handle back navigation in compose
- request and declare the required media read permissions across API levels

## Testing
- ⚠️ `./gradlew assembleDebug` *(fails: Gradle wrapper not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e14c138e308323aa396f8c21a4c89f