### PR TITLE
Add volume key capture support

### DIFF
--- a/app/src/main/java/io/mayu/birdpilot/MainActivity.kt
+++ b/app/src/main/java/io/mayu/birdpilot/MainActivity.kt
@@ -2,11 +2,17 @@ package io.mayu.birdpilot
 
 import android.Manifest
 import android.content.ContentValues
-import android.content.Context
 import android.content.pm.PackageManager
+import android.hardware.display.DisplayManager
 import android.os.Build
 import android.os.Bundle
+import android.os.Environment
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
 import android.provider.MediaStore
+import android.util.Log
+import android.view.KeyEvent
 import android.view.Surface
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -56,13 +62,161 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.Executor
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
 
 class MainActivity : ComponentActivity() {
+    private var previewView: PreviewView? = null
+    private var imageCapture: ImageCapture? = null
+    private lateinit var cameraExecutor: ExecutorService
+    private lateinit var mainExecutor: Executor
+    private val isCapturing = AtomicBoolean(false)
+    private var lastShotAt: Long = 0L
+    private var isCameraScreenVisible: Boolean = false
+    private lateinit var displayManager: DisplayManager
+    private val displayListener = object : DisplayManager.DisplayListener {
+        override fun onDisplayAdded(displayId: Int) = Unit
+
+        override fun onDisplayRemoved(displayId: Int) = Unit
+
+        override fun onDisplayChanged(displayId: Int) {
+            val view = previewView ?: return
+            val display = view.display ?: return
+            if (display.displayId == displayId) {
+                updateTargetRotation()
+            }
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        mainExecutor = ContextCompat.getMainExecutor(this)
+        cameraExecutor = Executors.newSingleThreadExecutor()
+        displayManager = getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+        displayManager.registerDisplayListener(displayListener, Handler(Looper.getMainLooper()))
         setContent {
             BirdPilotApp()
         }
+    }
+
+    override fun onDestroy() {
+        displayManager.unregisterDisplayListener(displayListener)
+        cameraExecutor.shutdown()
+        super.onDestroy()
+    }
+
+    override fun dispatchKeyEvent(ev: KeyEvent): Boolean {
+        if (isCameraScreenVisible &&
+            (ev.keyCode == KeyEvent.KEYCODE_VOLUME_UP || ev.keyCode == KeyEvent.KEYCODE_VOLUME_DOWN)
+        ) {
+            return when (ev.action) {
+                KeyEvent.ACTION_DOWN -> {
+                    if (ev.repeatCount == 0) {
+                        requestCapture()
+                    }
+                    true
+                }
+
+                KeyEvent.ACTION_UP -> true
+                else -> true
+            }
+        }
+        return super.dispatchKeyEvent(ev)
+    }
+
+    fun registerCameraComponents(preview: PreviewView, capture: ImageCapture) {
+        previewView = preview
+        imageCapture = capture
+        updateTargetRotation()
+    }
+
+    fun unregisterCameraComponents(preview: PreviewView) {
+        if (previewView === preview) {
+            previewView = null
+            imageCapture = null
+        }
+    }
+
+    fun setCameraScreenVisible(visible: Boolean) {
+        isCameraScreenVisible = visible
+    }
+
+    fun requestCapture() {
+        triggerCapture()
+    }
+
+    private fun triggerCapture(): Boolean {
+        val capture = imageCapture ?: return false
+        val preview = previewView ?: return false
+        val now = SystemClock.uptimeMillis()
+        if (now - lastShotAt < 500L) {
+            return false
+        }
+        if (!isCapturing.compareAndSet(false, true)) {
+            return false
+        }
+        lastShotAt = now
+
+        val contentResolver = contentResolver
+        cameraExecutor.execute {
+            try {
+                val rotation = preview.display?.rotation ?: Surface.ROTATION_0
+                capture.targetRotation = rotation
+                val displayName = SimpleDateFormat("yyyyMMdd_HHmmss_SSS", Locale.getDefault()).format(Date())
+                val contentValues = ContentValues().apply {
+                    put(MediaStore.MediaColumns.DISPLAY_NAME, displayName)
+                    put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
+                    put(
+                        MediaStore.Images.Media.RELATIVE_PATH,
+                        Environment.DIRECTORY_DCIM + "/BirdCam"
+                    )
+                }
+                val outputOptions = ImageCapture.OutputFileOptions.Builder(
+                    contentResolver,
+                    MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                    contentValues
+                ).build()
+
+                capture.takePicture(
+                    outputOptions,
+                    mainExecutor,
+                    object : ImageCapture.OnImageSavedCallback {
+                        override fun onImageSaved(outputFileResults: ImageCapture.OutputFileResults) {
+                            Toast.makeText(this@MainActivity, "Saved", Toast.LENGTH_SHORT).show()
+                            isCapturing.set(false)
+                        }
+
+                        override fun onError(exception: ImageCaptureException) {
+                            Toast.makeText(
+                                this@MainActivity,
+                                "Failed: ${'$'}{exception.message ?: exception.javaClass.simpleName}",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                            Log.e("MainActivity", "Failed to save image", exception)
+                            isCapturing.set(false)
+                        }
+                    }
+                )
+            } catch (throwable: Throwable) {
+                mainExecutor.execute {
+                    Toast.makeText(
+                        this@MainActivity,
+                        "Failed: ${'$'}{throwable.message ?: throwable.javaClass.simpleName}",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                    Log.e("MainActivity", "Failed to capture image", throwable)
+                    isCapturing.set(false)
+                }
+            }
+        }
+        return true
+    }
+
+    private fun updateTargetRotation() {
+        val capture = imageCapture ?: return
+        val rotation = previewView?.display?.rotation ?: Surface.ROTATION_0
+        capture.targetRotation = rotation
     }
 }
 
@@ -74,6 +228,7 @@ private enum class Screen {
 @Composable
 fun BirdPilotApp() {
     val context = LocalContext.current
+    val activity = context as? MainActivity
     val lifecycleOwner = LocalLifecycleOwner.current
     val cameraPermission = Manifest.permission.CAMERA
 
@@ -102,6 +257,10 @@ fun BirdPilotApp() {
         if (!allPermissionsGranted) {
             currentScreen = Screen.Camera
         }
+    }
+
+    LaunchedEffect(currentScreen, activity) {
+        activity?.setCameraScreenVisible(currentScreen == Screen.Camera)
     }
 
     val galleryPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -190,7 +349,13 @@ private fun CameraPreview(
             .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
             .build()
     }
-    val executor = remember { ContextCompat.getMainExecutor(context) }
+
+    DisposableEffect(activity, previewView, imageCapture) {
+        activity?.registerCameraComponents(previewView, imageCapture)
+        onDispose {
+            activity?.unregisterCameraComponents(previewView)
+        }
+    }
 
     DisposableEffect(lifecycleOwner) {
         val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
@@ -234,12 +399,7 @@ private fun CameraPreview(
                 .align(Alignment.BottomCenter)
                 .padding(bottom = 32.dp)
         ) {
-            capturePhoto(
-                context = context,
-                imageCapture = imageCapture,
-                executor = executor,
-                rotation = previewView.display?.rotation ?: Surface.ROTATION_0
-            )
+            activity?.requestCapture()
         }
     }
 }
@@ -265,41 +425,6 @@ private fun GalleryButton(
             textAlign = TextAlign.Center
         )
     }
-}
-
-private fun capturePhoto(
-    context: Context,
-    imageCapture: ImageCapture,
-    executor: Executor,
-    rotation: Int
-) {
-    imageCapture.targetRotation = rotation
-    val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
-    val fileName = "IMG_${'$'}timeStamp.jpg"
-    val contentValues = ContentValues().apply {
-        put(MediaStore.MediaColumns.DISPLAY_NAME, fileName)
-        put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
-        put(MediaStore.Images.Media.RELATIVE_PATH, "DCIM/BirdCam")
-    }
-    val outputOptions = ImageCapture.OutputFileOptions.Builder(
-        context.contentResolver,
-        MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
-        contentValues
-    ).build()
-
-    imageCapture.takePicture(
-        outputOptions,
-        executor,
-        object : ImageCapture.OnImageSavedCallback {
-            override fun onImageSaved(outputFileResults: ImageCapture.OutputFileResults) {
-                Toast.makeText(context, "保存しました", Toast.LENGTH_SHORT).show()
-            }
-
-            override fun onError(exception: ImageCaptureException) {
-                Toast.makeText(context, "保存に失敗しました", Toast.LENGTH_SHORT).show()
-            }
-        }
-    )
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- add an Activity-managed capture pipeline that consumes volume keys when the camera screen is visible and throttles repeated presses
- register camera components with the Activity so volume button shots reuse the existing ImageCapture and update target rotation on display changes
- save captures to MediaStore under DCIM/BirdCam with Saved/Failed toasts and error logging

## Testing
- ⚠️ `./gradlew assembleDebug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68e35a0149dc832395a2dd8959906dc9