### PR TITLE
Add gallery viewer with deletion workflow

### DIFF
--- a/app/src/main/java/io/mayu/birdpilot/GalleryScreen.kt
+++ b/app/src/main/java/io/mayu/birdpilot/GalleryScreen.kt
@@ -10,104 +10,165 @@ import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.IconButton
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @Composable
-fun GalleryScreen(onBack: () -> Unit) {
+fun GalleryScreen(
+    onBack: () -> Unit,
+    onOpen: (Uri) -> Unit,
+    onDelete: (Uri) -> Unit,
+    reloadSignal: Int
+) {
     BackHandler(onBack = onBack)
 
     val context = LocalContext.current
-    val imageUris = remember { mutableStateListOf<Uri>() }
+    var imageUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(false) }
+    var pendingDeleteUri by remember { mutableStateOf<Uri?>(null) }
+    val scope = rememberCoroutineScope()
 
-    LaunchedEffect(Unit) {
-        val result = runCatching {
-            withContext(Dispatchers.IO) {
-                loadLatestImages(context)
+    fun loadImages() {
+        scope.launch {
+            isLoading = true
+            val result = withContext(Dispatchers.IO) {
+                runCatching { loadGalleryImages(context) }
             }
+            result.onSuccess { uris ->
+                imageUris = uris
+            }.onFailure { throwable ->
+                if (throwable is SecurityException) {
+                    Toast.makeText(context, "写真へのアクセス許可が必要です", Toast.LENGTH_SHORT).show()
+                    onBack()
+                } else {
+                    Toast.makeText(context, "ギャラリーの読み込みに失敗しました", Toast.LENGTH_SHORT).show()
+                }
+            }
+            isLoading = false
         }
+    }
 
-        result.onSuccess { uris ->
-            imageUris.clear()
-            imageUris.addAll(uris)
-        }.onFailure { throwable ->
-            if (throwable is SecurityException) {
-                Toast.makeText(context, "写真へのアクセス許可が必要です", Toast.LENGTH_SHORT).show()
-                onBack()
-            }
-        }
+    LaunchedEffect(reloadSignal) {
+        loadImages()
     }
 
     Surface(color = Color.Black, modifier = Modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize()) {
-            GalleryTopBar(onBack = onBack)
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(3),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f),
-                contentPadding = PaddingValues(4.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-                horizontalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                items(imageUris, key = { it.toString() }) { uri ->
-                    GalleryThumbnail(uri = uri)
+            GalleryTopBar(
+                onBack = onBack,
+                onRefresh = { loadImages() },
+                isLoading = isLoading
+            )
+            if (imageUris.isEmpty() && !isLoading) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "BirdCamの写真がありません",
+                        color = Color.White.copy(alpha = 0.8f),
+                        textAlign = TextAlign.Center
+                    )
+                }
+            } else {
+                LazyVerticalGrid(
+                    columns = GridCells.Adaptive(minSize = 120.dp),
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(imageUris, key = { it.toString() }) { uri ->
+                        GalleryThumbnail(
+                            uri = uri,
+                            onClick = { onOpen(uri) },
+                            onLongClick = { pendingDeleteUri = uri }
+                        )
+                    }
                 }
             }
         }
     }
+
+    val targetDelete = pendingDeleteUri
+    if (targetDelete != null) {
+        AlertDialog(
+            onDismissRequest = { pendingDeleteUri = null },
+            title = { Text(text = "写真を削除") },
+            text = { Text(text = "この写真を削除しますか？") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        pendingDeleteUri = null
+                        onDelete(targetDelete)
+                    }
+                ) {
+                    Text(text = "削除")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDeleteUri = null }) {
+                    Text(text = "キャンセル")
+                }
+            }
+        )
+    }
 }
 
 @Composable
-private fun GalleryTopBar(onBack: () -> Unit) {
+private fun GalleryTopBar(
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    isLoading: Boolean
+) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .background(Color.Black)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
-        contentAlignment = Alignment.CenterStart
+            .padding(horizontal = 16.dp, vertical = 12.dp)
     ) {
-        IconButton(
+        TextButton(
             onClick = onBack,
-            modifier = Modifier
-                .size(40.dp)
-                .clip(CircleShape)
-                .background(Color.White.copy(alpha = 0.1f))
+            modifier = Modifier.align(Alignment.CenterStart)
         ) {
-            Text(text = "←", color = Color.White, style = MaterialTheme.typography.titleMedium)
+            Text(text = "戻る", color = Color.White)
         }
         Text(
             text = "ギャラリー",
@@ -115,18 +176,37 @@ private fun GalleryTopBar(onBack: () -> Unit) {
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.align(Alignment.Center)
         )
+        Row(
+            modifier = Modifier.align(Alignment.CenterEnd),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.padding(end = 8.dp),
+                    color = Color.White,
+                    strokeWidth = 2.dp
+                )
+            }
+            TextButton(onClick = onRefresh) {
+                Text(text = "再読み込み", color = Color.White)
+            }
+        }
     }
 }
 
 @Composable
-private fun GalleryThumbnail(uri: Uri) {
+private fun GalleryThumbnail(
+    uri: Uri,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit
+) {
     val context = LocalContext.current
     var bitmap by remember(uri) { mutableStateOf<Bitmap?>(null) }
 
     LaunchedEffect(uri) {
         bitmap = withContext(Dispatchers.IO) {
             runCatching {
-                context.contentResolver.loadThumbnail(uri, Size(300, 300), null)
+                context.contentResolver.loadThumbnail(uri, Size(200, 200), null)
             }.getOrNull()
         }
     }
@@ -135,7 +215,13 @@ private fun GalleryThumbnail(uri: Uri) {
         modifier = Modifier
             .aspectRatio(1f)
             .clip(MaterialTheme.shapes.small)
-            .background(Color.DarkGray),
+            .background(Color.DarkGray)
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    onTap = { onClick() },
+                    onLongPress = { onLongClick() }
+                )
+            },
         contentAlignment = Alignment.Center
     ) {
         val thumb = bitmap
@@ -147,15 +233,15 @@ private fun GalleryThumbnail(uri: Uri) {
                 contentScale = ContentScale.Crop
             )
         } else {
-            Text(text = "…", color = Color.White)
+            CircularProgressIndicator(color = Color.White, strokeWidth = 2.dp)
         }
     }
 }
 
-private fun loadLatestImages(context: Context): List<Uri> {
+private fun loadGalleryImages(context: Context): List<Uri> {
     val projection = arrayOf(MediaStore.Images.Media._ID)
-    val selection = "(${MediaStore.Images.Media.RELATIVE_PATH} LIKE ? OR ${MediaStore.Images.Media.BUCKET_DISPLAY_NAME} = ?)"
-    val selectionArgs = arrayOf("DCIM/BirdCam%", "BirdCam")
+    val selection = "${MediaStore.Images.Media.RELATIVE_PATH} LIKE ?"
+    val selectionArgs = arrayOf("DCIM/BirdCam%")
     val sortOrder = "${MediaStore.Images.Media.DATE_TAKEN} DESC"
 
     val uris = mutableListOf<Uri>()
@@ -167,9 +253,12 @@ private fun loadLatestImages(context: Context): List<Uri> {
         sortOrder
     )?.use { cursor ->
         val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID)
-        while (cursor.moveToNext() && uris.size < 20) {
+        while (cursor.moveToNext()) {
             val id = cursor.getLong(idColumn)
-            val contentUri = ContentUris.withAppendedId(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, id)
+            val contentUri = ContentUris.withAppendedId(
+                MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                id
+            )
             uris.add(contentUri)
         }
     }

--- a/app/src/main/java/io/mayu/birdpilot/PhotoViewerScreen.kt
+++ b/app/src/main/java/io/mayu/birdpilot/PhotoViewerScreen.kt
@@ -1,0 +1,174 @@
+package io.mayu.birdpilot
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.ImageDecoder
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import android.widget.Toast
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@Composable
+fun PhotoViewerScreen(
+    uri: Uri,
+    onBack: () -> Unit,
+    onDelete: (Uri) -> Unit
+) {
+    BackHandler(onBack = onBack)
+
+    val context = LocalContext.current
+    var bitmap by remember(uri) { mutableStateOf<Bitmap?>(null) }
+    var isLoading by remember { mutableStateOf(true) }
+    var showDeleteDialog by remember { mutableStateOf(false) }
+    var scale by remember(uri) { mutableStateOf(1f) }
+    var offset by remember(uri) { mutableStateOf(Offset.Zero) }
+
+    LaunchedEffect(uri) {
+        val result = withContext(Dispatchers.IO) {
+            runCatching { loadBitmap(context, uri) }
+        }
+        result.onSuccess { bmp ->
+            bitmap = bmp
+        }.onFailure {
+            Toast.makeText(context, "画像を読み込めませんでした", Toast.LENGTH_SHORT).show()
+            onBack()
+        }
+        isLoading = false
+    }
+
+    Surface(color = Color.Black, modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            val imageBitmap = bitmap
+            if (imageBitmap != null) {
+                Image(
+                    bitmap = imageBitmap.asImageBitmap(),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .pointerInput(uri) {
+                            detectTransformGestures { _, pan, zoom, _ ->
+                                val newScale = (scale * zoom).coerceIn(1f, 5f)
+                                val adjustedPan = if (newScale > 1f) pan else Offset.Zero
+                                scale = newScale
+                                offset = if (newScale <= 1f) {
+                                    Offset.Zero
+                                } else {
+                                    offset + adjustedPan
+                                }
+                            }
+                        }
+                        .pointerInput(uri) {
+                            detectTapGestures(
+                                onDoubleTap = {
+                                    scale = 1f
+                                    offset = Offset.Zero
+                                }
+                            )
+                        }
+                        .graphicsLayer(
+                            scaleX = scale,
+                            scaleY = scale,
+                            translationX = offset.x,
+                            translationY = offset.y
+                        ),
+                    contentScale = ContentScale.Fit
+                )
+            } else if (isLoading) {
+                CircularProgressIndicator(
+                    color = Color.White,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.TopCenter)
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                TextButton(onClick = onBack) {
+                    Text(
+                        text = "戻る",
+                        color = Color.White,
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                }
+                TextButton(onClick = { showDeleteDialog = true }) {
+                    Text(
+                        text = "削除",
+                        color = Color.White,
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                }
+            }
+        }
+    }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text(text = "写真を削除") },
+            text = { Text(text = "この写真を削除しますか？") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDeleteDialog = false
+                        onDelete(uri)
+                    }
+                ) {
+                    Text(text = "削除")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = false }) {
+                    Text(text = "キャンセル")
+                }
+            }
+        )
+    }
+}
+
+private fun loadBitmap(context: Context, uri: Uri): Bitmap {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        val source = ImageDecoder.createSource(context.contentResolver, uri)
+        ImageDecoder.decodeBitmap(source)
+    } else {
+        @Suppress("DEPRECATION")
+        MediaStore.Images.Media.getBitmap(context.contentResolver, uri)
+    }
+}


### PR DESCRIPTION
## Summary
- ギャラリー画面をDCIM/BirdCam配下の写真のみ表示するグリッドへ更新し、再読み込みと削除確認を実装
- ピンチズーム・ドラッグ・ダブルタップリセットに対応したPhotoViewer画面を追加
- MainActivityでselectedPhoto状態とMediaStore削除フローを組み込み、ギャラリーとビューワーを接続

## Testing
- ./gradlew :app:assembleDebug *(fails: Gradle wrapper is not present in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e370f881f083239509aaa1f357e1c5