### PR TITLE
Reset camera zoom on double tap

### DIFF
--- a/app/src/main/java/io/mayu/birdpilot/MainActivity.kt
+++ b/app/src/main/java/io/mayu/birdpilot/MainActivity.kt
@@ -534,6 +534,12 @@ private fun CameraPreview(
                     focusRingPosition = Offset(e.x, e.y)
                     return true
                 }
+
+                override fun onDoubleTap(e: MotionEvent): Boolean {
+                    val cam = currentCamera.value ?: return false
+                    cam.cameraControl.setLinearZoom(0f)
+                    return true
+                }
             }
         )
 


### PR DESCRIPTION
## Summary
- reset the camera preview zoom to 1.0x when the user double taps while keeping autofocus behavior on single tap

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e52e1cfcbc8323b2d5022fc3497c93