### PR TITLE
feat: double-tap to reset zoom (x1.0)

### DIFF
--- a/app/src/main/java/io/mayu/birdpilot/MainActivity.kt
+++ b/app/src/main/java/io/mayu/birdpilot/MainActivity.kt
@@ -534,6 +534,12 @@ private fun CameraPreview(
                     focusRingPosition = Offset(e.x, e.y)
                     return true
                 }
+
+                override fun onDoubleTap(e: MotionEvent): Boolean {
+                    val cam = currentCamera.value ?: return false
+                    cam.cameraControl.setLinearZoom(0f)
+                    return true
+                }
             }
         )
 


### PR DESCRIPTION
What: PreviewView の GestureDetector に onDoubleTap を追加し、setLinearZoom(0f) を実行

Why: 素早く等倍へ戻すショートカット

DoD: ダブルタップで x1.0、タップAF/ピンチは従来どおり