### PR TITLE
Add settings screen with shutter sound toggle

### DIFF
--- a/app/src/main/java/io/mayu/birdpilot/SettingsScreen.kt
+++ b/app/src/main/java/io/mayu/birdpilot/SettingsScreen.kt
@@ -1,0 +1,110 @@
+package io.mayu.birdpilot
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+@Composable
+fun SettingsScreen(
+    onBack: () -> Unit
+) {
+    BackHandler(onBack = onBack)
+
+    val context = LocalContext.current
+    val dataStore = remember(context) { context.cameraPreferenceDataStore }
+    val coroutineScope = rememberCoroutineScope()
+    val shutterSoundFlow = remember(dataStore) {
+        dataStore.data.map { preferences -> preferences[SHUTTER_SOUND_KEY] ?: false }
+    }
+    val shutterSoundEnabled by shutterSoundFlow.collectAsState(initial = false)
+
+    Surface(color = Color.Black, modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black)
+                .statusBarsPadding()
+                .padding(horizontal = 16.dp, vertical = 24.dp),
+            verticalArrangement = Arrangement.Top
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 24.dp)
+            ) {
+                TextButton(
+                    onClick = onBack,
+                    colors = ButtonDefaults.textButtonColors(contentColor = Color.White),
+                    modifier = Modifier.align(Alignment.CenterStart)
+                ) {
+                    Text(text = "← 戻る")
+                }
+                Text(
+                    text = "設定",
+                    color = Color.White,
+                    style = MaterialTheme.typography.titleMedium,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Text(
+                        text = "シャッター音",
+                        color = Color.White,
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Text(
+                        text = "ONにすると撮影時に効果音を再生します\n一部端末では端末仕様で音が鳴る場合があります",
+                        color = Color.White.copy(alpha = 0.7f),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+                Switch(
+                    checked = shutterSoundEnabled,
+                    onCheckedChange = { enabled ->
+                        coroutineScope.launch {
+                            dataStore.edit { preferences ->
+                                preferences[SHUTTER_SOUND_KEY] = enabled
+                            }
+                        }
+                    }
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a settings screen that exposes a persistent shutter sound toggle using the existing DataStore
- add a settings button to the camera overlay and navigate between camera, gallery, and settings screens
- conditionally play the shutter click sound with MediaActionSound when captures succeed and the toggle is enabled

## Testing
- Not run (missing Gradle wrapper)


------
https://chatgpt.com/codex/tasks/task_e_68e62c458e248323b8db19d001106482