### PR TITLE
test(hud): add HudStateTest + :app:verifyC2; fix lint (API<29 guard) & ChromeOS optional camera

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,6 +67,8 @@ dependencies {
 
     implementation("androidx.datastore:datastore-preferences:1.1.1")
 
+    testImplementation 'junit:junit:4.13.2'
+
 }
 
 // --- C1 verify task (Groovy DSL) ---
@@ -96,7 +98,11 @@ tasks.register("verifyC1") {
     }
 }
 
+// Aggregate task for C2 checks (HUD consistency etc.)
 tasks.register("verifyC2") {
+    group = "verification"               // ← カテゴリ表示用（"other"から移動）
+    description = "Run HUD consistency tests and lint"
     dependsOn("testDebugUnitTest", "lint")
 }
+
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.CAMERA" />
+    <!-- Camera is optional (ChromeOS などカメラ非搭載も許可) -->
+    <uses-feature android:name="android.hardware.camera.any" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"

--- a/app/src/main/java/io/mayu/birdpilot/GalleryScreen.kt
+++ b/app/src/main/java/io/mayu/birdpilot/GalleryScreen.kt
@@ -49,6 +49,10 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import android.os.Build
+import android.graphics.BitmapFactory
+import android.media.ThumbnailUtils
+
 
 @Composable
 fun GalleryScreen(
@@ -206,7 +210,20 @@ private fun GalleryThumbnail(
     LaunchedEffect(uri) {
         bitmap = withContext(Dispatchers.IO) {
             runCatching {
-                context.contentResolver.loadThumbnail(uri, Size(200, 200), null)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    context.contentResolver.loadThumbnail(uri, Size(200, 200), null)
+                } else {
+                    context.contentResolver.openInputStream(uri)?.use { ins ->
+                        BitmapFactory.decodeStream(ins)?.let { bm ->
+                            ThumbnailUtils.extractThumbnail(
+                                bm,
+                                200, 200,
+                                ThumbnailUtils.OPTIONS_RECYCLE_INPUT
+                            )
+                        }
+                    }
+                }
+
             }.getOrNull()
         }
     }


### PR DESCRIPTION
## Summary
- Add **HudStateTest** and wire aggregate task `:app:verifyC2`.
- Fix lint(NewApi): add SDK guard for `ContentResolver.loadThumbnail` (API<29 fallback).
- ChromeOS: mark camera features as **optional** in manifest.

## Changes
- `app/src/test/java/io/mayu/birdpilot/HudStateTest.kt`
- `app/src/main/java/io/mayu/birdpilot/GalleryScreen.kt` (API<29 fallback)
- `app/src/main/AndroidManifest.xml` (uses-feature required="false")
- `app/build.gradle` (verifyC2 group/description)

## Testing
- Local: `gradle :app:verifyC2` → **BUILD SUCCESSFUL**
- Manual: PA fire 1-shot OK / ROI frame presets 0.8/1.0/1.2 OK / C2 gate open path OK

## Acceptance
- HUD判定 `score >= roiTh` の境界テストがPASS
- Lintエラー0
- 既存C1/C2/Perch Assistの挙動に影響なし

## Risks / Rollback
- 低リスク。問題時は本PRのSquash commitをRevertで戻せます。

## Checklist
- [x] base = `main`
- [x] Merge method = **Squash**
- [x] Delete branch after merge
- [ ] Label: `tests`, `lint`, `chromeos`（任意）