### PR TITLE
feat(hud): HUD表示トグル追加＋hudEnabledでROI枠/テキストを抑止

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,6 +67,8 @@ dependencies {
 
     implementation("androidx.datastore:datastore-preferences:1.1.1")
 
+    testImplementation 'junit:junit:4.13.2'
+
 }
 
 // --- C1 verify task (Groovy DSL) ---
@@ -96,7 +98,11 @@ tasks.register("verifyC1") {
     }
 }
 
+// Aggregate task for C2 checks (HUD consistency etc.)
 tasks.register("verifyC2") {
+    group = "verification"               // ← カテゴリ表示用（"other"から移動）
+    description = "Run HUD consistency tests and lint"
     dependsOn("testDebugUnitTest", "lint")
 }
+
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.CAMERA" />
+    <!-- Camera is optional (ChromeOS などカメラ非搭載も許可) -->
+    <uses-feature android:name="android.hardware.camera.any" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"

--- a/app/src/main/java/io/mayu/birdpilot/GalleryScreen.kt
+++ b/app/src/main/java/io/mayu/birdpilot/GalleryScreen.kt
@@ -49,6 +49,10 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import android.os.Build
+import android.graphics.BitmapFactory
+import android.media.ThumbnailUtils
+
 
 @Composable
 fun GalleryScreen(
@@ -206,7 +210,20 @@ private fun GalleryThumbnail(
     LaunchedEffect(uri) {
         bitmap = withContext(Dispatchers.IO) {
             runCatching {
-                context.contentResolver.loadThumbnail(uri, Size(200, 200), null)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    context.contentResolver.loadThumbnail(uri, Size(200, 200), null)
+                } else {
+                    context.contentResolver.openInputStream(uri)?.use { ins ->
+                        BitmapFactory.decodeStream(ins)?.let { bm ->
+                            ThumbnailUtils.extractThumbnail(
+                                bm,
+                                200, 200,
+                                ThumbnailUtils.OPTIONS_RECYCLE_INPUT
+                            )
+                        }
+                    }
+                }
+
             }.getOrNull()
         }
     }

--- a/app/src/main/java/io/mayu/birdpilot/MainActivity.kt
+++ b/app/src/main/java/io/mayu/birdpilot/MainActivity.kt
@@ -498,6 +498,7 @@ private fun CameraPreview(
 ) {
     val context = LocalContext.current
     val roiTh by roiThresholdFlow(context).collectAsState(initial = 0.4f)
+    val hudEnabled by hudEnabledFlow(context).collectAsState(initial = true)
     val frameScale by roiFrameScaleFlow(context).collectAsState(initial = 1.0f)
     val activity = context as? MainActivity
     val executor = remember { ContextCompat.getMainExecutor(context) }
@@ -539,7 +540,7 @@ private fun CameraPreview(
             right  = (cx + halfW).coerceIn(left + 1, w.coerceAtLeast(left + 1))
             bottom = (cy + halfH).coerceIn(top + 1,  h.coerceAtLeast(top + 1))
         }
-        roi = scaled
+        roi = if (hudEnabled) scaled else null
         roiScore = score
 
         val hud = hudState(score, roiTh)
@@ -1154,15 +1155,20 @@ private fun CameraPreview(
             )
 
             // HUD: ROI の判定と score を右上に表示
-            Text(
-                text = "ROI $roiJudge  score=${String.format(Locale.US, "%.2f", roiScore ?: -1f)}",
-                color = Color.White,
-                fontSize = 14.sp,
-                modifier = Modifier
-                    .clip(RoundedCornerShape(6.dp))
-                    .background(Color(0x88000000))
-                    .padding(horizontal = 8.dp, vertical = 4.dp)
-            )
+            // HUD_TOGGLE_TEXT_BEGIN
+            if (hudEnabled) {
+                Text(
+                    text = "ROI $roiJudge  score=${String.format(Locale.US, "%.2f", roiScore ?: -1f)}",
+                    color = Color.White,
+                    fontSize = 14.sp,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(Color(0x88000000))
+                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                )
+            }
+            // HUD_TOGGLE_TEXT_END
+
 
             FinderToggleButton(
                 isEnabled = finderEnabled,

--- a/app/src/main/java/io/mayu/birdpilot/Prefs.kt
+++ b/app/src/main/java/io/mayu/birdpilot/Prefs.kt
@@ -33,6 +33,19 @@ suspend fun setRoiFrameScale(context: Context, value: Float) {
     context.cameraPreferenceDataStore.edit { it[ROI_FRAME_SCALE_KEY] = v }
 }
 
+// --- HUD visibility toggle ---------------------------------------------------
+private val HUD_ENABLED_KEY = booleanPreferencesKey("hud_enabled")
+
+/** HUDの表示可否（既定 true） */
+fun hudEnabledFlow(context: Context): Flow<Boolean> =
+    context.cameraPreferenceDataStore.data.map { it[HUD_ENABLED_KEY] ?: true }
+
+/** HUDの表示可否を保存 */
+suspend fun setHudEnabled(context: Context, enabled: Boolean) {
+    context.cameraPreferenceDataStore.edit { it[HUD_ENABLED_KEY] = enabled }
+}
+
+
 // DataStore (Preferences) をアプリ全体で共有
 val Context.cameraPreferenceDataStore by preferencesDataStore(name = "camera_preferences")
 

--- a/app/src/main/java/io/mayu/birdpilot/SettingsScreen.kt
+++ b/app/src/main/java/io/mayu/birdpilot/SettingsScreen.kt
@@ -36,6 +36,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import androidx.compose.material3.Slider
 import java.util.Locale
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+
 
 // Prefs のAPIを使う場合（おすすめ）
 import io.mayu.birdpilot.roiThresholdFlow
@@ -63,11 +66,14 @@ fun SettingsScreen(
     val finderProfile by finderProfileFlow.collectAsState(initial = FinderProfile.OUTDOOR)
 
     Surface(color = Color.Black, modifier = Modifier.fillMaxSize()) {
+        val scroll = rememberScrollState()
+
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .background(Color.Black)
                 .statusBarsPadding()
+                .verticalScroll(scroll)
                 .padding(horizontal = 16.dp, vertical = 24.dp),
             verticalArrangement = Arrangement.Top
         ) {
@@ -250,7 +256,33 @@ fun SettingsScreen(
                         )
                     }
                 }
+
             }
+
+            // HUD_TOGGLE_BEGIN
+            val hudEnabled by hudEnabledFlow(context).collectAsState(initial = true)
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 24.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "HUD表示",
+                    color = Color.White,
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                Switch(
+                    checked = hudEnabled,
+                    onCheckedChange = { v ->
+                        coroutineScope.launch { setHudEnabled(context, v) }
+                    }
+                )
+            }
+            // HUD_TOGGLE_END
+
 
         }
 


### PR DESCRIPTION
## Summary
- 設定画面に **HUD表示** スイッチを追加（DataStore: `hud_enabled`、既定ON）。
- `MainActivity`: `hudEnabled` により **ROI枠** と **右上HUDテキスト** を非表示にできるように。
- 既存の判定（C1/C2/Perch Assist）はそのまま動作。

## Changes
- `Prefs.kt`: hudEnabledFlow / setHudEnabled 追加
- `SettingsScreen.kt`: HUDスイッチUI（HUD_TOGGLE_BEGIN/END）
- `MainActivity.kt`: `roi = if (hudEnabled) ...`、HUDテキストを `if (hudEnabled)` でラップ（HUD_TOGGLE_TEXT_*）

## Testing
- HUD表示=OFF → 枠/テキストとも非表示、`PA fire` ログは出る。
- HUD表示=ON → 従来どおり表示。
- ローカル実機（Pixelエミュ）で確認。

## Acceptance
- スイッチの即時反映（DataStore）／再起動後も設定保持。
- 既存機能（C1/C2/Perch Assist）に副作用なし。

## Checklist
- [x] base = `main`
- [x] Merge method = **Squash**
- [x] Delete branch after merge
- [ ] Label: `hud`, `ux`（任意）

